### PR TITLE
Add simple CSV test runner

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <input type="text" id="testName" placeholder="テスト名">
     <input type="file" id="csvInput" accept=".csv">
     <button id="addTestBtn">追加</button>
+    <button id="runTestBtn">テスト実行</button>
   </section>
   <section id="list">
     <h2>テスト一覧</h2>


### PR DESCRIPTION
## Summary
- add `テスト実行` button to start a simple test using the uploaded CSV
- implement simple test mode in `script.js` that shows the first question and toggles answer with `k`

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_b_684d42538dc4832b9af94ca29b395d91